### PR TITLE
First cflib2 demo implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 **/app/**/*.o
 **/app/**/*.cmd
 **/__pycache__/
+*.egg-info/
 
 #vscode config folder
 .vscode/

--- a/demos/scripts/README.md
+++ b/demos/scripts/README.md
@@ -7,6 +7,7 @@ Host-side scripts that communicate with a Crazyflie over radio. Each script runs
 | Category | Language / Library | Description |
 |----------|--------------------|-------------|
 | [cflib](cflib/) | Python / [crazyflie-lib-python](https://github.com/bitcraze/crazyflie-lib-python) | Broad Python library covering the full Crazyflie API with many examples |
+| [cflib2](cflib2/) | Python / [crazyflie-lib-python-v2](https://github.com/bitcraze/crazyflie-lib-python-v2) | High-performance Python library built on top of [crazyflie-lib-rs](https://github.com/bitcraze/crazyflie-lib-rs) with an async-first API |
 | [rust](rust/) | Rust / [crazyflie-lib-rs](https://github.com/bitcraze/crazyflie-lib-rs) | High-performance Rust alternative with a focused API and async support |
 
 ## Firmware Prerequisite

--- a/demos/scripts/cflib2/README.md
+++ b/demos/scripts/cflib2/README.md
@@ -1,0 +1,31 @@
+# cflib2 Demos
+
+Python examples using [cflib2](https://github.com/bitcraze/crazyflie-lib-python-v2), the async Rust-powered Python library for Crazyflie drones.
+
+cflib2 is a ground-up rewrite of the original cflib with an async-first API. It is not API-compatible with cflib. Building cflib2 from source requires a Rust toolchain.
+
+Each demo is self-contained with its own `pyproject.toml` declaring its dependencies.
+
+## Prerequisites
+
+- [uv](https://docs.astral.sh/uv/) package manager
+- [Rust toolchain](https://rustup.rs/) (required to build cflib2 from source)
+
+## Running with uv (recommended)
+
+```bash
+cd demos/scripts/cflib2/<category>/<demo>
+uv run <script>.py
+```
+
+uv creates a `.venv` in the demo directory, installs dependencies (compiling the Rust extension), and runs the script. On subsequent runs it reuses the existing environment.
+
+## Running with pip
+
+```bash
+cd demos/scripts/cflib2/<category>/<demo>
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+python3 <script>.py
+```

--- a/demos/scripts/cflib2/autonomy/high_level_commander/README.md
+++ b/demos/scripts/cflib2/autonomy/high_level_commander/README.md
@@ -1,0 +1,36 @@
+# High-Level Commander
+
+Demonstrates autonomous flight using the high-level commander: take off, move to positions, fly a spiral, and land.
+
+Uses the async [cflib2](https://github.com/bitcraze/crazyflie-lib-python-v2) library.
+
+## What You Need
+
+- **Crazyflie platform**
+- **Crazyradio**
+- **Flow deck v2 or Positioning system**
+
+## Quick Start
+
+```bash
+uv run high_level_commander.py --uri radio://0/80/2M/E7E7E7E7E7
+```
+
+## What Happens
+
+When you run the demo:
+
+1. **Connects** to the Crazyflie at the specified URI
+2. **Takes off** - Rises to 0.5 m
+3. **Moves** to two waypoints
+4. **Spiral** - Flies a full 360° spiral
+5. **Lands** - Returns to ground and stops motors
+
+## Dependencies
+
+- firmware:
+  - repo: https://github.com/bitcraze/crazyflie-firmware.git
+  - ref: 2026.04
+- cflib2:
+  - repo: https://github.com/bitcraze/crazyflie-lib-python-v2.git
+  - ref: 329bd2cb6b21ccecce0396926887743c148a6bd6

--- a/demos/scripts/cflib2/autonomy/high_level_commander/high_level_commander.py
+++ b/demos/scripts/cflib2/autonomy/high_level_commander/high_level_commander.py
@@ -1,0 +1,88 @@
+# ,---------,       ____  _ __
+# |  ,-^-,  |      / __ )(_) /_______________ _____  ___
+# | (  O  ) |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+# | / ,--'  |    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#    +------`   /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+# Copyright (C) 2026 Bitcraze AB
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+import math
+from dataclasses import dataclass
+
+import tyro
+
+from cflib2 import Crazyflie, LinkContext
+
+
+@dataclass
+class Args:
+    uri: str = "radio://0/80/2M/E7E7E7E7E7"
+    """Crazyflie URI"""
+
+
+async def main() -> None:
+    args = tyro.cli(Args)
+
+    ctx = LinkContext()
+
+    print(f"Connecting to {args.uri}...")
+    cf = await Crazyflie.connect_from_uri(ctx, args.uri)
+    print("Connected!")
+
+    hlc = cf.high_level_commander()
+
+    print("Taking off...")
+    try:
+        await hlc.take_off(0.5, None, 2.0, None)
+    except Exception as e:
+        print(f"Take-off failed: {e}")
+    await asyncio.sleep(2.1)
+
+    print("Going to first position...")
+    try:
+        await hlc.go_to(0.25, 0.25, 0.25, 0.0, 2.0, True, False, None)
+    except Exception as e:
+        print(f"Go-to failed: {e}")
+    await asyncio.sleep(2.1)
+
+    print("Going to second position...")
+    try:
+        await hlc.go_to(-0.25, -0.25, -0.25, 0.0, 2.0, True, False, None)
+    except Exception as e:
+        print(f"Go-to failed: {e}")
+    await asyncio.sleep(2.1)
+
+    print("Moving in a spiral...")
+    try:
+        await hlc.spiral(-math.pi * 2.0, 0.5, 0.5, 0.0, 5.0, True, True, None)
+    except Exception as e:
+        print(f"Spiral failed: {e}")
+    await asyncio.sleep(5.1)
+
+    print("Landing...")
+    try:
+        await hlc.land(0.0, None, 2.0, None)
+    except Exception as e:
+        print(f"Landing failed: {e}")
+    await asyncio.sleep(2.1)
+
+    await hlc.stop(None)
+    print("Done")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/demos/scripts/cflib2/autonomy/high_level_commander/pyproject.toml
+++ b/demos/scripts/cflib2/autonomy/high_level_commander/pyproject.toml
@@ -5,4 +5,5 @@ description = "Flies a sequence of positions using the high-level commander, pow
 requires-python = ">=3.11"
 dependencies = [
     "cflib2 @ git+https://github.com/bitcraze/crazyflie-lib-python-v2.git@329bd2cb6b21ccecce0396926887743c148a6bd6",
+    "tyro>=1.0.8",
 ]

--- a/demos/scripts/cflib2/autonomy/high_level_commander/pyproject.toml
+++ b/demos/scripts/cflib2/autonomy/high_level_commander/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "high-level-commander-cflib2"
+version = "0.1.0"
+description = "Flies a sequence of positions using the high-level commander, powered by the async cflib2 library."
+requires-python = ">=3.11"
+dependencies = [
+    "cflib2 @ git+https://github.com/bitcraze/crazyflie-lib-python-v2.git@329bd2cb6b21ccecce0396926887743c148a6bd6",
+]


### PR DESCRIPTION
This pull request introduces a new category of demo scripts using `cflib2`.

**New cflib2 demo infrastructure and documentation:**

* Added a new `cflib2` section to the main `demos/scripts/README.md`.
* Created `demos/scripts/cflib2/README.md` with detailed setup and usage instructions for running `cflib2`-based demos.

**High-level commander autonomous flight demo:**

* Added a new demo in `demos/scripts/cflib2/autonomy/high_level_commander/`:
  - `README.md`
  - `pyproject.toml`
  - `high_level_commander.py`
  
  A difference between `cflib2/` and the already implemented `cflib/` and `rust/` demos is the dependency to a specific commit of the repo instead of a release.