### PR TITLE
Rust demos

### DIFF
--- a/demos/scripts/rust/Cargo.lock
+++ b/demos/scripts/rust/Cargo.lock
@@ -118,6 +118,29 @@ dependencies = [
 
 [[package]]
 name = "crazyflie-lib"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fc2cb8f0c7a428e980d9abe632f1263da4cb2d6acf83f1855e69d4cdb28cb8"
+dependencies = [
+ "async-broadcast",
+ "async-stream",
+ "async-trait",
+ "crazyflie-link",
+ "crc32fast",
+ "flume",
+ "futures",
+ "futures-util",
+ "half",
+ "hex",
+ "libc",
+ "num_enum",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "crazyflie-lib"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d54f64d51934a7f2941df5f98efb858fb68ed1e075c1b6f164e50598825279"
@@ -442,7 +465,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "high-level-commander"
 version = "0.1.0"
 dependencies = [
- "crazyflie-lib",
+ "crazyflie-lib 0.6.0",
  "crazyflie-link",
  "tokio",
 ]

--- a/demos/scripts/rust/Cargo.lock
+++ b/demos/scripts/rust/Cargo.lock
@@ -615,6 +615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "led-mem-set"
+version = "0.1.0"
+dependencies = [
+ "crazyflie-lib 0.7.1",
+ "crazyflie-link",
+ "tokio",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/demos/scripts/rust/Cargo.lock
+++ b/demos/scripts/rust/Cargo.lock
@@ -624,6 +624,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "led-param-set"
+version = "0.1.0"
+dependencies = [
+ "crazyflie-lib 0.7.1",
+ "crazyflie-link",
+ "tokio",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/demos/scripts/rust/Cargo.lock
+++ b/demos/scripts/rust/Cargo.lock
@@ -54,6 +54,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "autonomous-sequence-high-level"
+version = "0.1.0"
+dependencies = [
+ "crazyflie-lib 0.7.1",
+ "crazyflie-link",
+ "tokio",
+]
+
+[[package]]
+name = "autonomous-sequence-high-level-compressed"
+version = "0.1.0"
+dependencies = [
+ "crazyflie-lib 0.7.1",
+ "crazyflie-link",
+ "tokio",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/demos/scripts/rust/Cargo.toml
+++ b/demos/scripts/rust/Cargo.toml
@@ -5,5 +5,6 @@
 members = [
     "autonomy/high_level_commander",
     "led-ring/led_mem_set",
+    "led-ring/led_param_set",
 ]
 resolver = "2"

--- a/demos/scripts/rust/Cargo.toml
+++ b/demos/scripts/rust/Cargo.toml
@@ -4,6 +4,8 @@
 [workspace]
 members = [
     "autonomy/high_level_commander",
+    "autonomy/autonomous_sequence_high_level",
+    "autonomy/autonomous_sequence_high_level_compressed",
     "led-ring/led_mem_set",
     "led-ring/led_param_set",
 ]

--- a/demos/scripts/rust/Cargo.toml
+++ b/demos/scripts/rust/Cargo.toml
@@ -4,5 +4,6 @@
 [workspace]
 members = [
     "autonomy/high_level_commander",
+    "led-ring/led_mem_set",
 ]
 resolver = "2"

--- a/demos/scripts/rust/README.md
+++ b/demos/scripts/rust/README.md
@@ -20,11 +20,3 @@ cargo run
 ```
 
 Cargo fetches dependencies, compiles, and runs the binary. On subsequent runs it reuses the build cache.
-
-## Demos
-
-### autonomy
-
-| Demo | Description |
-|------|-------------|
-| [high_level_commander](autonomy/high_level_commander/) | Take off, move to waypoints, fly a spiral, and land using the high-level commander |

--- a/demos/scripts/rust/autonomy/autonomous_sequence_high_level/Cargo.toml
+++ b/demos/scripts/rust/autonomy/autonomous_sequence_high_level/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "autonomous-sequence-high-level"
+version = "0.1.0"
+edition = "2021"
+description = "Figure-8 trajectory demo using uncompressed Poly4D upload and the high-level commander"
+publish = false
+
+[[bin]]
+name = "autonomous_sequence_high_level"
+path = "autonomous_sequence_high_level.rs"
+
+[dependencies]
+crazyflie-lib  = "0.7.0"
+crazyflie-link = "0.4.3"
+tokio          = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/demos/scripts/rust/autonomy/autonomous_sequence_high_level/README.md
+++ b/demos/scripts/rust/autonomy/autonomous_sequence_high_level/README.md
@@ -1,0 +1,40 @@
+# Autonomous Sequence - High Level Commander
+
+Demonstrates autonomous flight by uploading a Poly4D figure-8 trajectory to the Crazyflie and executing it with the high-level commander.
+
+## What You Need
+
+- **Crazyflie platform**
+- **Crazyradio**
+- **Flow deck v2 or Positioning system**
+
+## Quick Start
+
+Edit the URI in `autonomous_sequence_high_level.rs` to match your Crazyflie's radio address, then:
+
+```bash
+cargo run
+```
+
+## What Happens
+
+When you run the demo:
+
+1. **Connects** to the Crazyflie at the specified URI
+2. **Uploads** a Poly4D figure-8 trajectory to trajectory memory
+3. **Resets** the Kalman estimator
+4. **Takes off** - Rises to 1.0 m
+5. **Flies figure-8** - Executes the trajectory relative to the starting position
+6. **Lands** - Returns to ground and stops motors
+
+## Dependencies
+
+- firmware:
+  - repo: https://github.com/bitcraze/crazyflie-firmware.git
+  - ref: 2026.04
+- crazyflie-lib-rs:
+  - repo: https://github.com/bitcraze/crazyflie-lib-rs.git
+  - ref: 0.7.0
+- crazyflie-link-rs:
+  - repo: https://github.com/bitcraze/crazyflie-link-rs.git
+  - ref: 0.4.3

--- a/demos/scripts/rust/autonomy/autonomous_sequence_high_level/autonomous_sequence_high_level.rs
+++ b/demos/scripts/rust/autonomy/autonomous_sequence_high_level/autonomous_sequence_high_level.rs
@@ -1,0 +1,92 @@
+use crazyflie_lib::subsystems::memory::{MemoryType, Poly4D, Poly, TrajectoryMemory};
+use crazyflie_link::LinkContext;
+use crazyflie_lib::Crazyflie;
+use tokio::time::{sleep, Duration};
+
+const URI: &str = "radio://0/80/2M/E7E7E7E7E7";
+const TRAJECTORY_ID: u8 = 1;
+const TRAJECTORY_DURATION_S: f64 = 7.3;
+
+// Figure-8 trajectory. Each row: [duration, x0..x7, y0..y7, z0..z7, yaw0..yaw7]
+// Generated with https://github.com/whoenig/uav_trajectories
+#[rustfmt::skip]
+const FIGURE8: &[[f32; 33]] = &[
+    [1.050000,  0.000000, -0.000000,  0.000000, -0.000000,  0.830443, -0.276140, -0.384219,  0.180493, -0.000000,  0.000000, -0.000000,  0.000000, -1.356107,  0.688430,  0.587426, -0.329106,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.710000,  0.396058,  0.918033,  0.128965, -0.773546,  0.339704,  0.034310, -0.026417, -0.030049, -0.445604, -0.684403,  0.888433,  1.493630, -1.361618, -0.139316,  0.158875,  0.095799,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.620000,  0.922409,  0.405715, -0.582968, -0.092188, -0.114670,  0.101046,  0.075834, -0.037926, -0.291165,  0.967514,  0.421451, -1.086348,  0.545211,  0.030109, -0.050046, -0.068177,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.700000,  0.923174, -0.431533, -0.682975,  0.177173,  0.319468, -0.043852, -0.111269,  0.023166,  0.289869,  0.724722, -0.512011, -0.209623, -0.218710,  0.108797,  0.128756, -0.055461,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.560000,  0.405364, -0.834716,  0.158939,  0.288175, -0.373738, -0.054995,  0.036090,  0.078627,  0.450742, -0.385534, -0.954089,  0.128288,  0.442620,  0.055630, -0.060142, -0.076163,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.560000,  0.001062, -0.646270, -0.012560, -0.324065,  0.125327,  0.119738,  0.034567, -0.063130,  0.001593, -1.031457,  0.015159,  0.820816, -0.152665, -0.130729, -0.045679,  0.080444,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.700000, -0.402804, -0.820508, -0.132914,  0.236278,  0.235164, -0.053551, -0.088687,  0.031253, -0.449354, -0.411507,  0.902946,  0.185335, -0.239125, -0.041696,  0.016857,  0.016709,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.620000, -0.921641, -0.464596,  0.661875,  0.286582, -0.228921, -0.051987,  0.004669,  0.038463, -0.292459,  0.777682,  0.565788, -0.432472, -0.060568, -0.082048, -0.009439,  0.041158,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [0.710000, -0.923935,  0.447832,  0.627381, -0.259808, -0.042325, -0.032258,  0.001420,  0.005294,  0.288570,  0.873350, -0.515586, -0.730207, -0.026023,  0.288755,  0.215678, -0.148061,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    [1.053185, -0.398611,  0.850510, -0.144007, -0.485368, -0.079781,  0.176330,  0.234482, -0.153567,  0.447039, -0.532729, -0.855023,  0.878509,  0.775168, -0.391051, -0.713519,  0.391628,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,  0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+];
+
+fn figure8_segments() -> Vec<Poly4D> {
+    FIGURE8.iter().map(|row| {
+        Poly4D::new(
+            row[0],
+            Poly::from_slice(&row[1..9]),
+            Poly::from_slice(&row[9..17]),
+            Poly::from_slice(&row[17..25]),
+            Poly::from_slice(&row[25..33]),
+        )
+    }).collect()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let context = LinkContext::new();
+    let cf = Crazyflie::connect_from_uri(&context, URI, crazyflie_lib::NoTocCache).await?;
+
+    // Upload trajectory
+    println!("Uploading trajectory...");
+    let segments = figure8_segments();
+    let num_pieces = segments.len() as u8;
+    let memories = cf.memory.get_memories(Some(MemoryType::Trajectory));
+    match cf.memory.open_memory::<TrajectoryMemory>(memories[0].clone()).await {
+        Some(Ok(traj_mem)) => {
+            traj_mem.write_uncompressed(&segments, 0).await?;
+            cf.memory.close_memory(traj_mem).await?;
+        }
+        Some(Err(e)) => return Err(e.into()),
+        None => return Err("Failed to open trajectory memory".into()),
+    }
+    cf.high_level_commander.define_trajectory(TRAJECTORY_ID, 0, num_pieces, None).await?;
+    println!("Trajectory uploaded ({:.1}s)", TRAJECTORY_DURATION_S);
+
+    // Reset estimator
+    cf.param.set("kalman.resetEstimation", 1u8).await?;
+    sleep(Duration::from_millis(100)).await;
+    cf.param.set("kalman.resetEstimation", 0u8).await?;
+    sleep(Duration::from_secs(1)).await;
+
+    // Arm and fly
+    cf.platform.send_arming_request(true).await?;
+    sleep(Duration::from_secs(1)).await;
+
+    println!("Taking off...");
+    if let Err(e) = cf.high_level_commander.take_off(1.0, None, 2.0, None).await {
+        eprintln!("Take-off failed: {e}");
+    }
+    sleep(Duration::from_secs(3)).await;
+
+    println!("Starting trajectory...");
+    if let Err(e) = cf.high_level_commander.start_trajectory(TRAJECTORY_ID, 1.0, true, false, false, None).await {
+        eprintln!("Start trajectory failed: {e}");
+    }
+    sleep(Duration::from_secs_f64(TRAJECTORY_DURATION_S)).await;
+
+    println!("Landing...");
+    if let Err(e) = cf.high_level_commander.land(0.0, None, 2.0, None).await {
+        eprintln!("Land failed: {e}");
+    }
+    sleep(Duration::from_secs(2)).await;
+
+    cf.high_level_commander.stop(None).await?;
+    println!("Done");
+
+    cf.disconnect().await;
+    Ok(())
+}

--- a/demos/scripts/rust/autonomy/autonomous_sequence_high_level_compressed/Cargo.toml
+++ b/demos/scripts/rust/autonomy/autonomous_sequence_high_level_compressed/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "autonomous-sequence-high-level-compressed"
+version = "0.1.0"
+edition = "2021"
+description = "Figure-8 trajectory demo using compressed trajectory upload and the high-level commander"
+publish = false
+
+[[bin]]
+name = "autonomous_sequence_high_level_compressed"
+path = "autonomous_sequence_high_level_compressed.rs"
+
+[dependencies]
+crazyflie-lib  = "0.7.0"
+crazyflie-link = "0.4.3"
+tokio          = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/demos/scripts/rust/autonomy/autonomous_sequence_high_level_compressed/README.md
+++ b/demos/scripts/rust/autonomy/autonomous_sequence_high_level_compressed/README.md
@@ -1,0 +1,40 @@
+# Autonomous Sequence - High Level Commander (Compressed)
+
+Demonstrates autonomous flight by uploading a compressed polynomial figure-8 trajectory to the Crazyflie and executing it with the high-level commander.
+
+## What You Need
+
+- **Crazyflie platform**
+- **Crazyradio**
+- **Flow deck v2 or Positioning system**
+
+## Quick Start
+
+Edit the URI in `autonomous_sequence_high_level_compressed.rs` to match your Crazyflie's radio address, then:
+
+```bash
+cargo run
+```
+
+## What Happens
+
+When you run the demo:
+
+1. **Connects** to the Crazyflie at the specified URI
+2. **Uploads** a compressed figure-8 trajectory to trajectory memory
+3. **Resets** the Kalman estimator
+4. **Takes off** - Rises to 1.0 m
+5. **Flies figure-8** - Executes the trajectory relative to the starting position
+6. **Lands** - Returns to ground and stops motors
+
+## Dependencies
+
+- firmware:
+  - repo: https://github.com/bitcraze/crazyflie-firmware.git
+  - ref: 2026.04
+- crazyflie-lib-rs:
+  - repo: https://github.com/bitcraze/crazyflie-lib-rs.git
+  - ref: 0.7.0
+- crazyflie-link-rs:
+  - repo: https://github.com/bitcraze/crazyflie-link-rs.git
+  - ref: 0.4.3

--- a/demos/scripts/rust/autonomy/autonomous_sequence_high_level_compressed/autonomous_sequence_high_level_compressed.rs
+++ b/demos/scripts/rust/autonomy/autonomous_sequence_high_level_compressed/autonomous_sequence_high_level_compressed.rs
@@ -1,0 +1,75 @@
+use crazyflie_lib::subsystems::memory::{MemoryType, CompressedStart, CompressedSegment, TrajectoryMemory};
+use crazyflie_lib::subsystems::high_level_commander::TRAJECTORY_TYPE_POLY4D_COMPRESSED;
+use crazyflie_link::LinkContext;
+use crazyflie_lib::Crazyflie;
+use tokio::time::{sleep, Duration};
+
+const URI: &str = "radio://0/80/2M/E7E7E7E7E7";
+const TRAJECTORY_ID: u8 = 1;
+const TRAJECTORY_DURATION_S: u64 = 8;
+
+const A: f32 = 0.9;
+const B: f32 = 0.5;
+const C: f32 = 0.5;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let context = LinkContext::new();
+    let cf = Crazyflie::connect_from_uri(&context, URI, crazyflie_lib::NoTocCache).await?;
+
+    // Upload compressed trajectory
+    println!("Uploading trajectory...");
+    let start = CompressedStart::new(0.0, 0.0, 0.0, 0.0);
+    let segments = vec![
+        CompressedSegment::new(2.0, vec![0.0, 1.0, 1.0], vec![0.0,  A,  0.0], vec![], vec![])?,
+        CompressedSegment::new(2.0, vec![1.0, B,  0.0], vec![-A,  -C,  0.0], vec![], vec![])?,
+        CompressedSegment::new(2.0, vec![-B, -1.0, -1.0], vec![C,   A,  0.0], vec![], vec![])?,
+        CompressedSegment::new(2.0, vec![-1.0, 0.0, 0.0], vec![-A,  0.0, 0.0], vec![], vec![])?,
+    ];
+    let num_pieces = segments.len() as u8;
+    let memories = cf.memory.get_memories(Some(MemoryType::Trajectory));
+    match cf.memory.open_memory::<TrajectoryMemory>(memories[0].clone()).await {
+        Some(Ok(traj_mem)) => {
+            traj_mem.write_compressed(&start, &segments, 0).await?;
+            cf.memory.close_memory(traj_mem).await?;
+        }
+        Some(Err(e)) => return Err(e.into()),
+        None => return Err("Failed to open trajectory memory".into()),
+    }
+    cf.high_level_commander.define_trajectory(TRAJECTORY_ID, 0, num_pieces, Some(TRAJECTORY_TYPE_POLY4D_COMPRESSED)).await?;
+    println!("Trajectory uploaded ({}s)", TRAJECTORY_DURATION_S);
+
+    // Reset estimator
+    cf.param.set("kalman.resetEstimation", 1u8).await?;
+    sleep(Duration::from_millis(100)).await;
+    cf.param.set("kalman.resetEstimation", 0u8).await?;
+    sleep(Duration::from_secs(1)).await;
+
+    // Arm and fly
+    cf.platform.send_arming_request(true).await?;
+    sleep(Duration::from_secs(1)).await;
+
+    println!("Taking off...");
+    if let Err(e) = cf.high_level_commander.take_off(1.0, None, 2.0, None).await {
+        eprintln!("Take-off failed: {e}");
+    }
+    sleep(Duration::from_secs(3)).await;
+
+    println!("Starting trajectory...");
+    if let Err(e) = cf.high_level_commander.start_trajectory(TRAJECTORY_ID, 1.0, true, false, false, None).await {
+        eprintln!("Start trajectory failed: {e}");
+    }
+    sleep(Duration::from_secs(TRAJECTORY_DURATION_S)).await;
+
+    println!("Landing...");
+    if let Err(e) = cf.high_level_commander.land(0.0, None, 2.0, None).await {
+        eprintln!("Land failed: {e}");
+    }
+    sleep(Duration::from_secs(2)).await;
+
+    cf.high_level_commander.stop(None).await?;
+    println!("Done");
+
+    cf.disconnect().await;
+    Ok(())
+}

--- a/demos/scripts/rust/autonomy/high_level_commander/Cargo.toml
+++ b/demos/scripts/rust/autonomy/high_level_commander/Cargo.toml
@@ -10,6 +10,6 @@ name = "high_level_commander"
 path = "high_level_commander.rs"
 
 [dependencies]
-crazyflie-lib  = "0.7.0"
+crazyflie-lib  = "0.6.0"
 crazyflie-link = "0.4.3"
 tokio          = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/demos/scripts/rust/led-ring/led_mem_set/Cargo.toml
+++ b/demos/scripts/rust/led-ring/led_mem_set/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "led-mem-set"
+version = "0.1.0"
+edition = "2021"
+description = "LED ring demo using LED driver memory with crazyflie-lib-rs"
+publish = false
+
+[[bin]]
+name = "led_mem_set"
+path = "led_mem_set.rs"
+
+[dependencies]
+crazyflie-lib  = "0.7.0"
+crazyflie-link = "0.4.3"
+tokio          = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/demos/scripts/rust/led-ring/led_mem_set/README.md
+++ b/demos/scripts/rust/led-ring/led_mem_set/README.md
@@ -1,0 +1,46 @@
+# LED Ring - Memory Set
+
+Connects to a Crazyflie and sets individual LEDs on the LED-ring deck by writing directly to LED memory.
+
+## What You Need
+
+- **Crazyflie platform**
+- **Crazyradio**
+- **LED-ring deck**
+
+## Quick Start
+
+Edit the URI in `led_mem_set.rs` to match your Crazyflie's radio address, then:
+
+```bash
+cargo run
+```
+
+## What Happens
+
+When you run the demo:
+
+1. **Connects** to the Crazyflie at the specified URI
+2. **Sets** the ring effect to memory-controlled mode
+3. **Writes** RGB values to four individual LEDs:
+   - LED 0: green
+   - LED 3: blue
+   - LED 6: red
+   - LED 9: white
+4. **Waits** 2 seconds, then disconnects
+
+The demo showcases:
+- Writing to LED memory via crazyflie-lib-rs
+- Controlling individual LEDs on the LED-ring deck
+
+## Dependencies
+
+- firmware:
+  - repo: https://github.com/bitcraze/crazyflie-firmware.git
+  - ref: 2026.04
+- crazyflie-lib-rs:
+  - repo: https://github.com/bitcraze/crazyflie-lib-rs.git
+  - ref: 0.7.0
+- crazyflie-link-rs:
+  - repo: https://github.com/bitcraze/crazyflie-link-rs.git
+  - ref: 0.4.3

--- a/demos/scripts/rust/led-ring/led_mem_set/led_mem_set.rs
+++ b/demos/scripts/rust/led-ring/led_mem_set/led_mem_set.rs
@@ -1,0 +1,45 @@
+use crazyflie_lib::subsystems::memory::{LedDriverMemory, MemoryType};
+
+const URI: &str = "radio://0/80/2M/E7E7E7E7E7";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let link_context = crazyflie_link::LinkContext::new();
+    let cf = crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI, crazyflie_lib::NoTocCache).await?;
+
+    cf.param.set("ring.effect", 13u8).await?;
+
+    let memories = cf.memory.get_memories(Some(MemoryType::DriverLed));
+
+    if memories.is_empty() {
+        println!("No LED driver memory found. Is the LED ring deck attached?");
+    } else {
+        match cf
+            .memory
+            .open_memory::<LedDriverMemory>(memories[0].clone())
+            .await
+        {
+            Some(Ok(mut leds)) => {
+                leds.leds[0].set(0, 100, 0, None);    // green
+                leds.leds[3].set(0, 0, 100, None);    // blue
+                leds.leds[6].set(100, 0, 0, None);    // red
+                leds.leds[9].set(100, 100, 100, None); // white
+
+                leds.write_leds().await?;
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+                cf.memory.close_memory(leds).await?;
+            }
+            Some(Err(e)) => {
+                println!("Could not access LED driver memory: {}", e);
+            }
+            None => {
+                println!("LED driver memory not found");
+            }
+        };
+    }
+
+    cf.disconnect().await;
+
+    Ok(())
+}

--- a/demos/scripts/rust/led-ring/led_param_set/Cargo.toml
+++ b/demos/scripts/rust/led-ring/led_param_set/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "led-param-set"
+version = "0.1.0"
+edition = "2021"
+description = "LED ring demo setting parameters with crazyflie-lib-rs"
+publish = false
+
+[[bin]]
+name = "led_param_set"
+path = "led_param_set.rs"
+
+[dependencies]
+crazyflie-lib  = "0.7.0"
+crazyflie-link = "0.4.3"
+tokio          = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/demos/scripts/rust/led-ring/led_param_set/README.md
+++ b/demos/scripts/rust/led-ring/led_param_set/README.md
@@ -1,0 +1,38 @@
+# LED Ring - Parameter Set
+
+Demonstrates controlling the LED-ring deck by setting `ring.*` parameters directly - including solid color and fade-to-color effects.
+
+## What You Need
+
+- **Crazyflie platform**
+- **Crazyradio**
+- **LED-ring deck**
+
+## Quick Start
+
+Edit the URI in `led_param_set.rs` to match your Crazyflie's radio address, then:
+
+```bash
+cargo run
+```
+
+## What Happens
+
+When you run the demo:
+
+1. **Connect** - Connects to the Crazyflie
+2. **Solid red** - Sets effect 7 (solid color) with red at value 100 for 2 seconds
+3. **Off** - Sets effect 0 (off) for 1 second
+4. **Fade** - Sets effect 14 (fade to color) with a 1-second fade time, cycling through blue, green, and red
+
+## Dependencies
+
+- firmware:
+  - repo: https://github.com/bitcraze/crazyflie-firmware.git
+  - ref: 2026.04
+- crazyflie-lib-rs:
+  - repo: https://github.com/bitcraze/crazyflie-lib-rs.git
+  - ref: 0.7.0
+- crazyflie-link-rs:
+  - repo: https://github.com/bitcraze/crazyflie-link-rs.git
+  - ref: 0.4.3

--- a/demos/scripts/rust/led-ring/led_param_set/led_param_set.rs
+++ b/demos/scripts/rust/led-ring/led_param_set/led_param_set.rs
@@ -1,0 +1,32 @@
+const URI: &str = "radio://0/55/2M/BADC0DE013";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let link_context = crazyflie_link::LinkContext::new();
+    let cf = crazyflie_lib::Crazyflie::connect_from_uri(&link_context, URI, crazyflie_lib::NoTocCache).await?;
+
+    // Solid red
+    cf.param.set("ring.effect", 7u8).await?;
+    cf.param.set("ring.solidRed", 100u8).await?;
+    cf.param.set("ring.solidGreen", 0u8).await?;
+    cf.param.set("ring.solidBlue", 0u8).await?;
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    // Off
+    cf.param.set("ring.effect", 0u8).await?;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // Fade to color
+    cf.param.set("ring.effect", 14u8).await?;
+    cf.param.set("ring.fadeTime", 1.0f32).await?;
+    cf.param.set("ring.fadeColor", 0x0000A0u32).await?; // blue
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    cf.param.set("ring.fadeColor", 0x00A000u32).await?; // green
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    cf.param.set("ring.fadeColor", 0xA00000u32).await?; // red
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    cf.disconnect().await;
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request adds several new Rust demo projects for the Crazyflie platform, focusing on autonomous flight with trajectory uploads and LED ring control. The changes include new example binaries, their documentation, and updates to the workspace configuration to include these demos.

**Autonomy demos:**

-  `autonomous_sequence_high_level` 
-  `autonomous_sequence_high_level_compressed` 

**LED-ring demos:**
- `led_mem_set` 
- `led_param_set` 

**Workspace and documentation updates:**

* Updated the workspace `Cargo.toml` to include all new demo projects.
* Cleaned up the root `README.md` by removing the outdated demos section.

**Other:**
* Changed the version for `crazyflie-lib` dependency in the `high_level_commander` example, to check how Cargo.lock handles different dependencies across different demos.
