### PR TITLE
Use params.yaml as default file

### DIFF
--- a/demos/scripts/cflib/parameters/persistent_params_from_file/persistent_params_from_file.py
+++ b/demos/scripts/cflib/parameters/persistent_params_from_file/persistent_params_from_file.py
@@ -47,7 +47,8 @@ logging.basicConfig(level=logging.ERROR)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', '--file', type=str, help='The yaml file containing the arguments. ')
+    parser.add_argument('-f', '--file', type=str, default='params.yaml',
+                         help='The yaml file containing the arguments. (default: params.yaml)')
     args = parser.parse_args()
 
     cflib.crtp.init_drivers()


### PR DESCRIPTION
In example persistent_params_from_file, there is an example yaml file, but it is not used by default.

Update example to use this file by default, so script runs without any input.